### PR TITLE
Converting logging into spotify use cases to CA

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ using 17 as jdk
    - have the user copy the entire url and paste it back into the program
    - use `getCodeFromURI(String uri)` to extract code from uri, and pass that into `createUserAccessToken(String code)`
      - This will create codes for SpotifyAccount, that will be allow various other methods to work.
+
+## Entities
+### Songs
+ - We wil be using ISRC codes for our songs (for now), Spotify and Amazon include these in their track objects

--- a/src/data_access/SpotifyDataAccessObject.java
+++ b/src/data_access/SpotifyDataAccessObject.java
@@ -8,6 +8,7 @@ import okhttp3.*;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import use_case.OpenLoginSpotify.OpenLoginSpotifyDataAccessInterface;
 
 import java.awt.*;
 import java.io.IOException;
@@ -18,7 +19,7 @@ import java.util.Base64;
 import java.util.Iterator;
 import java.util.List;
 
-public class SpotifyDataAccessObject {
+public class SpotifyDataAccessObject implements OpenLoginSpotifyDataAccessInterface {
     private String clientSecret = Secrets.spotifyClientSecret;
 
     private String clientID = "b273f4e8f44d44168fe8c86492e95f86";
@@ -31,15 +32,15 @@ public class SpotifyDataAccessObject {
     // USER DETAILS
     private String displayName;
     private String userID;
-    void openLoginPage(){
-        openLoginPage(false);
+    public String getLoginPage(){
+        return getLoginPage(false);
     }
 
     /**
      *
      * @param forceLogin: TRUE - makes user sign in regardless if DuckGum has already been authorized.
      */
-    void openLoginPage(boolean forceLogin){
+    String getLoginPage(boolean forceLogin){
         JSONObject params = new JSONObject();
         params.put("client_id", clientID)
                 .put("response_type", "code")
@@ -49,14 +50,8 @@ public class SpotifyDataAccessObject {
             params.put("show_dialog", "true");
         }
 
+        return "https://accounts.spotify.com/authorize?" + encodeJSON(params);
 
-        try {
-            Desktop.getDesktop()
-                    .browse(URI.create("https://accounts.spotify.com/authorize?" + encodeJSON(params)));
-
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     /**

--- a/src/data_access/SpotifyDataAccessObject.java
+++ b/src/data_access/SpotifyDataAccessObject.java
@@ -1,19 +1,27 @@
-package entities;
+package data_access;
 
 import Secrets.Secrets;
 import entities.Builders.SongFactory;
+import entities.Playlist;
+import entities.SpotifyAccount;
 import okhttp3.*;
-import org.json.*;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.awt.*;
 import java.io.IOException;
+import java.net.URI;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Iterator;
 import java.util.List;
 
-public class SpotifyAccount extends MusicService{
-    private String clientID = "b273f4e8f44d44168fe8c86492e95f86";
+public class SpotifyDataAccessObject {
     private String clientSecret = Secrets.spotifyClientSecret;
+
+    private String clientID = "b273f4e8f44d44168fe8c86492e95f86";
     private final String url = "https://accounts.spotify.com/api/";
     private final String redirectURI = "https://github.com/TeenI126/CSC207DuckGum";
     private String accessToken = null;
@@ -23,12 +31,6 @@ public class SpotifyAccount extends MusicService{
     // USER DETAILS
     private String displayName;
     private String userID;
-    private List<Playlist> playlists;
-    // DAO
-    public SpotifyAccount(String userID, List<Playlist> playlists){
-        this.userID = userID;
-        this.playlists = playlists;
-    }
     void openLoginPage(){
         openLoginPage(false);
     }
@@ -37,25 +39,25 @@ public class SpotifyAccount extends MusicService{
      *
      * @param forceLogin: TRUE - makes user sign in regardless if DuckGum has already been authorized.
      */
-//    void openLoginPage(boolean forceLogin){
-//        JSONObject params = new JSONObject();
-//        params.put("client_id", clientID)
-//                .put("response_type", "code")
-//                .put("redirect_uri", redirectURI)
-//                .put("scope", "user-read-private user-read-email playlist-read-private playlist-read-collaborative");
-//        if (forceLogin){
-//            params.put("show_dialog", "true");
-//        }
-//
-//
-//        try {
-//            Desktop.getDesktop()
-//                    .browse(URI.create("https://accounts.spotify.com/authorize?" + encodeJSON(params)));
-//
-//        } catch (IOException e) {
-//            throw new RuntimeException(e);
-//        }
-//    }
+    void openLoginPage(boolean forceLogin){
+        JSONObject params = new JSONObject();
+        params.put("client_id", clientID)
+                .put("response_type", "code")
+                .put("redirect_uri", redirectURI)
+                .put("scope", "user-read-private user-read-email playlist-read-private playlist-read-collaborative");
+        if (forceLogin){
+            params.put("show_dialog", "true");
+        }
+
+
+        try {
+            Desktop.getDesktop()
+                    .browse(URI.create("https://accounts.spotify.com/authorize?" + encodeJSON(params)));
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     /**
      * TEMPORARY MEASURE, after a user logs into their spotify account, they will be redirected to a URI containing
@@ -63,10 +65,10 @@ public class SpotifyAccount extends MusicService{
      *
      * @param uri
      */
-//    public String getCodeFromURI(String uri){
-//        //remove base uri, leaving extension with code left.
-//        return uri.substring(47);
-//    }
+    public String getCodeFromURI(String uri){
+        //remove base uri, leaving extension with code left.
+        return uri.substring(47);
+    }
 
     /**
      *
@@ -74,77 +76,86 @@ public class SpotifyAccount extends MusicService{
      * @throws NoAccessTokenException, happens when the users login is no longer active and needs to log in via url from
      * openLoginPage()
      */
-//    public String getUserAccessToken() throws NoAccessTokenException {
-//        if (accessToken == null){
-//            throw new NoAccessTokenException();
-//        } else if (accessTokenExpires.isAfter(LocalDateTime.now())) {
-//            refreshAccessToken();
-//            return accessToken;
-//        } else {
-//            return accessToken;
-//        }
-//    }
-//    public void createNewUserAccessToken(String code){
-//
-//        OkHttpClient client = new OkHttpClient().newBuilder().build();
-//        RequestBody body = RequestBody.create(
-//                MediaType.parse("application/x-www-form-urlencoded"),
-//                "grant_type=authorization_code&code="+code+"&redirect_uri="+redirectURI
-//                );
-//
-//        Request request = new Request.Builder()
-//                .url(url + "token")
-//                .addHeader(
-//                        "Authorization","Basic " +
-//                                Base64.getEncoder().encodeToString((clientID+":"+clientSecret).getBytes())
-//                )
-//                .addHeader("Content-Type", "application/x-www-form-urlencoded")
-//                .method("POST",body)
-//                .build();
-//
-//
-//        JSONObject responseJSON;
-//        try {
-//            Response response = client.newCall(request).execute();
-//            responseJSON = new JSONObject(response.body().string());
-//        } catch (IOException e) {
-//            throw new RuntimeException(e);
-//        }
-//        //TODO handle not status 200 messages like a failed log in.
-//        accessToken = responseJSON.getString("access_token");
-//        refreshToken = responseJSON.getString("refresh_token");
-//        accessTokenExpires = LocalDateTime.now().plusSeconds(responseJSON.getInt("expires_in")-60);
-//        try {
-//            updateSpotifyInformation();
-//        } catch (NoAccessTokenException e) {
-//            throw new RuntimeException(e);
-//        }
-//
-//
-//    }
+    public String getUserAccessToken() throws NoAccessTokenException {
+        if (accessToken == null){
+            throw new NoAccessTokenException();
+        } else if (accessTokenExpires.isAfter(LocalDateTime.now())) {
+            refreshAccessToken();
+            return accessToken;
+        } else {
+            return accessToken;
+        }
+    }
 
-    private void updateSpotifyInformation() throws NoAccessTokenException {
-//        OkHttpClient client = new OkHttpClient().newBuilder().build();
-//
-//        Request request = new Request.Builder()
-//                .addHeader("Authorization", "Bearer " + getUserAccessToken())
-//                .url("https://api.spotify.com/v1/me")
-//                .method("GET",null)
-//                .build();
-//
-//        JSONObject responseJSON;
-//        try {
-//            Response response = client.newCall(request).execute();
-//            responseJSON = new JSONObject(response.body().string());
-//        } catch (IOException e) {
-//            throw new RuntimeException(e);
-//        }
-//        userID = responseJSON.getString("id");
-//        displayName = responseJSON.getString("display_name");
+    private void refreshAccessToken() {
+    }
+
+    private boolean isUserAccessTokenValid(){
+        //TODO
+        return true;
+    }
+
+    public void createNewUserAccessToken(String code){
+
+        OkHttpClient client = new OkHttpClient().newBuilder().build();
+        RequestBody body = RequestBody.create(
+                MediaType.parse("application/x-www-form-urlencoded"),
+                "grant_type=authorization_code&code="+code+"&redirect_uri="+redirectURI
+        );
+
+        Request request = new Request.Builder()
+                .url(url + "token")
+                .addHeader(
+                        "Authorization","Basic " +
+                                Base64.getEncoder().encodeToString((clientID+":"+clientSecret).getBytes())
+                )
+                .addHeader("Content-Type", "application/x-www-form-urlencoded")
+                .method("POST",body)
+                .build();
+
+
+        JSONObject responseJSON;
+        try {
+            Response response = client.newCall(request).execute();
+            responseJSON = new JSONObject(response.body().string());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        //TODO handle not status 200 messages like a failed log in.
+        accessToken = responseJSON.getString("access_token");
+        refreshToken = responseJSON.getString("refresh_token");
+        accessTokenExpires = LocalDateTime.now().plusSeconds(responseJSON.getInt("expires_in")-60);
+        try {
+            updateSpotifyInformation();
+        } catch (NoAccessTokenException e) {
+            throw new RuntimeException(e);
+        }
+
 
     }
 
-    public List<Playlist> getPlaylists() throws NoAccessTokenException {
+    private void updateSpotifyInformation() throws NoAccessTokenException {
+        OkHttpClient client = new OkHttpClient().newBuilder().build();
+
+        Request request = new Request.Builder()
+                .addHeader("Authorization", "Bearer " + getUserAccessToken())
+                .url("https://api.spotify.com/v1/me")
+                .method("GET",null)
+                .build();
+
+        JSONObject responseJSON;
+        try {
+            Response response = client.newCall(request).execute();
+            responseJSON = new JSONObject(response.body().string());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        userID = responseJSON.getString("id");
+        displayName = responseJSON.getString("display_name");
+
+    }
+
+    public java.util.List<Playlist> getPlaylists() throws NoAccessTokenException {
         OkHttpClient client = new OkHttpClient().newBuilder().build();
 
         Request request = new Request.Builder()
@@ -248,6 +259,22 @@ public class SpotifyAccount extends MusicService{
             throw new RuntimeException(e);
         }
     }
+
+    public SpotifyAccount getSpotifyAccount(String codeFromRedirectURI) {
+        createNewUserAccessToken(codeFromRedirectURI);
+
+        try {
+            updateSpotifyInformation();
+            return new SpotifyAccount(userID, getPlaylists());
+        } catch (NoAccessTokenException e) {
+            throw new RuntimeException(e); //TODO add failed login handling
+        }
+
+
+    }
     class NoAccessTokenException extends Exception{}
+
+
+
 
 }

--- a/src/data_access/SpotifyDataAccessObject.java
+++ b/src/data_access/SpotifyDataAccessObject.java
@@ -61,12 +61,6 @@ public class SpotifyDataAccessObject implements OpenLoginSpotifyDataAccessInterf
         return uri.substring(47);
     }
 
-    /**
-     *
-     * @return String with user's access token, which can be used to do various actions through API
-     * @throws NoAccessTokenException, happens when the users login is no longer active and needs to log in via url from
-     * openLoginPage()
-     */
     private void refreshAccessToken() {
         //TODO
     }

--- a/src/data_access/SpotifyDataAccessObject.java
+++ b/src/data_access/SpotifyDataAccessObject.java
@@ -109,14 +109,9 @@ public class SpotifyDataAccessObject implements OpenLoginSpotifyDataAccessInterf
 
         SpotifyAccount spotifyAccount =  new SpotifyAccount(accessToken,refreshToken,accessTokenExpires);
 
-        try {
-            updateSpotifyInformation(spotifyAccount, accessToken);
-        } catch (NoAccessTokenException e) {
-            throw new RuntimeException(e);
-        }
+        updateSpotifyInformation(spotifyAccount, accessToken);//adds user id and display name
 
-
-
+        return spotifyAccount;
 
     }
 
@@ -225,30 +220,30 @@ public class SpotifyDataAccessObject implements OpenLoginSpotifyDataAccessInterf
         return retString.toString().replaceAll(" ","+");
     }
 
-    /**
-     * This is for an application token NOT linked to a user
-     */
-    void updateToken(){
-
-        MediaType mediaType = MediaType.parse("application/x-www-form-urlencoded");
-        OkHttpClient client = new OkHttpClient().newBuilder().build();
-        RequestBody body = RequestBody.create(mediaType, "grant_type:client_credentials");
-        Request request = new Request.Builder().url(url+"token")
-                .method("POST",body)
-                .addHeader("Authorization", "Basic" + Base64.getEncoder().encodeToString((clientID+":"+clientSecret).getBytes()))
-                .addHeader("Content-Type", "application/x-www-form-urlencoded")
-                .build();
-
-        try {
-            Response response = client.newCall(request).execute();
-            JSONObject responseJSON = new JSONObject(response.body().string());
-
-            accessToken = responseJSON.getString("access_token");
-
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
+//    /**
+//     * This is for an application token NOT linked to a user
+//     */
+//    void updateToken(){
+//
+//        MediaType mediaType = MediaType.parse("application/x-www-form-urlencoded");
+//        OkHttpClient client = new OkHttpClient().newBuilder().build();
+//        RequestBody body = RequestBody.create(mediaType, "grant_type:client_credentials");
+//        Request request = new Request.Builder().url(url+"token")
+//                .method("POST",body)
+//                .addHeader("Authorization", "Basic" + Base64.getEncoder().encodeToString((clientID+":"+clientSecret).getBytes()))
+//                .addHeader("Content-Type", "application/x-www-form-urlencoded")
+//                .build();
+//
+//        try {
+//            Response response = client.newCall(request).execute();
+//            JSONObject responseJSON = new JSONObject(response.body().string());
+//
+//            String accessToken = responseJSON.getString("access_token");
+//
+//        } catch (IOException e) {
+//            throw new RuntimeException(e);
+//        }
+//    }
 
     public SpotifyAccount getSpotifyAccount(String codeFromRedirectURI) {
         createSpotifyAccountFromCode(codeFromRedirectURI);

--- a/src/entities/Account.java
+++ b/src/entities/Account.java
@@ -38,4 +38,7 @@ public class Account {
         }
         return playlists;
     }
+    public void addMusicService(MusicService musicService){
+        musicAccount.add(musicService);
+    }
 }

--- a/src/entities/MusicService.java
+++ b/src/entities/MusicService.java
@@ -3,7 +3,7 @@ package entities;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public class MusicService {
+public abstract class MusicService {
     // API Referencing
     private String accessToken = null;
     private String refreshToken = null;

--- a/src/interface_adapter/LogInSpotify/LogInSpotifyController.java
+++ b/src/interface_adapter/LogInSpotify/LogInSpotifyController.java
@@ -3,7 +3,6 @@ package interface_adapter.LogInSpotify;
 import entities.Account;
 import use_case.LogInSpotify.LogInSpotifyInputBoundary;
 import use_case.LogInSpotify.LogInSpotifyInputData;
-import use_case.LogInSpotify.LogInSpotifyInteractor;
 
 public class LogInSpotifyController {
     LogInSpotifyInputBoundary interactor;

--- a/src/interface_adapter/LogInSpotify/LogInSpotifyController.java
+++ b/src/interface_adapter/LogInSpotify/LogInSpotifyController.java
@@ -1,5 +1,6 @@
 package interface_adapter.LogInSpotify;
 
+import entities.Account;
 import use_case.LogInSpotify.LogInSpotifyInputBoundary;
 import use_case.LogInSpotify.LogInSpotifyInputData;
 import use_case.LogInSpotify.LogInSpotifyInteractor;
@@ -11,7 +12,7 @@ public class LogInSpotifyController {
         this.interactor = interactor;
     }
 
-    public void execute(LogInSpotifyInputData inputData){
-        interactor.execute();
+    public void execute(String code, Account activeAccount){
+        interactor.execute(new LogInSpotifyInputData(code, activeAccount));
     }
 }

--- a/src/interface_adapter/LogInSpotify/LogInSpotifyPresenter.java
+++ b/src/interface_adapter/LogInSpotify/LogInSpotifyPresenter.java
@@ -1,12 +1,10 @@
 package interface_adapter.LogInSpotify;
 
-import interface_adapter.OpenSpotifyLogin.OpenSpotifyLoginViewModel;
 import interface_adapter.ViewManagerModel;
 import use_case.LogInSpotify.LogInSpotifyOutputBoundary;
 
 public class LogInSpotifyPresenter implements LogInSpotifyOutputBoundary {
     private LogInSpotifyViewModel logInSpotifyViewModel;
-
     private ViewManagerModel viewManagerModel;
     @Override
     public void prepareSuccessView() {

--- a/src/interface_adapter/LogInSpotify/LogInSpotifyPresenter.java
+++ b/src/interface_adapter/LogInSpotify/LogInSpotifyPresenter.java
@@ -1,0 +1,21 @@
+package interface_adapter.LogInSpotify;
+
+import interface_adapter.OpenSpotifyLogin.OpenSpotifyLoginViewModel;
+import interface_adapter.ViewManagerModel;
+import use_case.LogInSpotify.LogInSpotifyOutputBoundary;
+
+public class LogInSpotifyPresenter implements LogInSpotifyOutputBoundary {
+    private LogInSpotifyViewModel logInSpotifyViewModel;
+
+    private ViewManagerModel viewManagerModel;
+    @Override
+    public void prepareSuccessView() {
+        LogInSpotifyState state = logInSpotifyViewModel.getState();
+        state.setLogInSuccessful(true);
+    }
+
+    @Override
+    public void prepareFailView() {
+        logInSpotifyViewModel.getState().setLogInSuccessful(false);
+    }
+}

--- a/src/interface_adapter/LogInSpotify/LogInSpotifyState.java
+++ b/src/interface_adapter/LogInSpotify/LogInSpotifyState.java
@@ -1,0 +1,9 @@
+package interface_adapter.LogInSpotify;
+
+public class LogInSpotifyState {
+    Boolean logInSuccessfull = null;
+
+    public void setLogInSuccessful(boolean logInSuccessfull){
+        this.logInSuccessfull = logInSuccessfull;
+    }
+}

--- a/src/interface_adapter/LogInSpotify/LogInSpotifyViewModel.java
+++ b/src/interface_adapter/LogInSpotify/LogInSpotifyViewModel.java
@@ -1,0 +1,25 @@
+package interface_adapter.LogInSpotify;
+
+import interface_adapter.ViewModel;
+
+public class LogInSpotifyViewModel extends ViewModel {
+    LogInSpotifyState state = new LogInSpotifyState();
+
+    public LogInSpotifyViewModel() {
+        super("Log In Spotify ViewModel");
+    }
+
+    public LogInSpotifyState getState() {
+        return state;
+    }
+
+    @Override
+    public void firePropertyChanged() {
+        //TODO firePropertyChanged for LogInSpotifyViewModel
+    }
+
+    @Override
+    public void addPropertyChangeListener() {
+        //TODO addPropertyChangeListener for LogInSpotifyViewModel
+    }
+}

--- a/src/interface_adapter/OpenSpotifyLogin/OpenSpotifyLoginController.java
+++ b/src/interface_adapter/OpenSpotifyLogin/OpenSpotifyLoginController.java
@@ -1,0 +1,7 @@
+package interface_adapter.OpenSpotifyLogin;
+
+public class OpenSpotifyLoginController {
+    public void execute(){
+
+    }
+}

--- a/src/interface_adapter/OpenSpotifyLogin/OpenSpotifyLoginController.java
+++ b/src/interface_adapter/OpenSpotifyLogin/OpenSpotifyLoginController.java
@@ -1,7 +1,15 @@
 package interface_adapter.OpenSpotifyLogin;
 
-public class OpenSpotifyLoginController {
-    public void execute(){
+import use_case.OpenLoginSpotify.OpenLoginSpotifyInputBoundary;
 
+public class OpenSpotifyLoginController {
+
+    OpenLoginSpotifyInputBoundary openLoginSpotifyInputInteractor;
+
+    public OpenSpotifyLoginController(OpenLoginSpotifyInputBoundary interactor){
+        openLoginSpotifyInputInteractor = interactor;
+    }
+    public void execute(){
+        openLoginSpotifyInputInteractor.execute();//no input data needed.
     }
 }

--- a/src/interface_adapter/OpenSpotifyLogin/OpenSpotifyLoginPresenter.java
+++ b/src/interface_adapter/OpenSpotifyLogin/OpenSpotifyLoginPresenter.java
@@ -13,6 +13,7 @@ public class OpenSpotifyLoginPresenter implements OpenLoginSpotifyOutputBoundary
 
     @Override
     public void openLoginCallbackURL(OpenLoginSpotifyOutputData data) {
-
+        viewModel.getState().setCallbackUrl(data.getCallback_url());
+        viewModel.firePropertyChanged();
     }
 }

--- a/src/interface_adapter/OpenSpotifyLogin/OpenSpotifyLoginPresenter.java
+++ b/src/interface_adapter/OpenSpotifyLogin/OpenSpotifyLoginPresenter.java
@@ -1,0 +1,18 @@
+package interface_adapter.OpenSpotifyLogin;
+
+import use_case.OpenLoginSpotify.OpenLoginSpotifyOutputBoundary;
+import use_case.OpenLoginSpotify.OpenLoginSpotifyOutputData;
+
+public class OpenSpotifyLoginPresenter implements OpenLoginSpotifyOutputBoundary {
+
+    OpenSpotifyLoginViewModel viewModel;
+
+    public OpenSpotifyLoginPresenter(OpenSpotifyLoginViewModel viewModel) {
+        this.viewModel = viewModel;
+    }
+
+    @Override
+    public void openLoginCallbackURL(OpenLoginSpotifyOutputData data) {
+
+    }
+}

--- a/src/interface_adapter/OpenSpotifyLogin/OpenSpotifyLoginState.java
+++ b/src/interface_adapter/OpenSpotifyLogin/OpenSpotifyLoginState.java
@@ -1,0 +1,9 @@
+package interface_adapter.OpenSpotifyLogin;
+
+public class OpenSpotifyLoginState {
+    String callbackUrl = "";
+
+    public void setCallbackUrl(String callbackUrl) {
+        this.callbackUrl = callbackUrl;
+    }
+}

--- a/src/interface_adapter/OpenSpotifyLogin/OpenSpotifyLoginViewModel.java
+++ b/src/interface_adapter/OpenSpotifyLogin/OpenSpotifyLoginViewModel.java
@@ -1,0 +1,4 @@
+package interface_adapter.OpenSpotifyLogin;
+
+public class OpenSpotifyLoginViewModel {
+}

--- a/src/interface_adapter/OpenSpotifyLogin/OpenSpotifyLoginViewModel.java
+++ b/src/interface_adapter/OpenSpotifyLogin/OpenSpotifyLoginViewModel.java
@@ -1,4 +1,24 @@
 package interface_adapter.OpenSpotifyLogin;
 
-public class OpenSpotifyLoginViewModel {
+import interface_adapter.ViewModel;
+
+public class OpenSpotifyLoginViewModel extends ViewModel {
+    OpenSpotifyLoginState state = new OpenSpotifyLoginState();
+
+    public OpenSpotifyLoginViewModel() {
+        super("Open Log in Spotify");
+    }
+
+    public OpenSpotifyLoginState getState() {
+        return state;
+    }
+
+    public void firePropertyChanged() {
+        //TODO Something to do with a class called Property changed support.
+    }
+
+    @Override
+    public void addPropertyChangeListener() {
+        //TODO
+    }
 }

--- a/src/interface_adapter/ViewManagerModel.java
+++ b/src/interface_adapter/ViewManagerModel.java
@@ -1,0 +1,4 @@
+package interface_adapter;
+
+public class ViewManagerModel {
+}

--- a/src/interface_adapter/ViewModel.java
+++ b/src/interface_adapter/ViewModel.java
@@ -1,7 +1,7 @@
 package interface_adapter;
 
 public abstract class ViewModel {
-    private String viewName;
+    private final String viewName;
 
     public ViewModel(String viewName) {this.viewName = viewName;}
 

--- a/src/interface_adapter/ViewModel.java
+++ b/src/interface_adapter/ViewModel.java
@@ -1,0 +1,15 @@
+package interface_adapter;
+
+public abstract class ViewModel {
+    private String viewName;
+
+    public ViewModel(String viewName) {this.viewName = viewName;}
+
+    public String getViewName() {
+        return viewName;
+    }
+
+    public abstract void firePropertyChanged();
+
+    public abstract void addPropertyChangeListener();
+}

--- a/src/use_case/AddSong/AddSongInputBoundary.java
+++ b/src/use_case/AddSong/AddSongInputBoundary.java
@@ -1,2 +1,3 @@
-package use_case.AddSong;public class AddSongInputBoundary {
+package use_case.AddSong;
+public interface AddSongInputBoundary {
 }

--- a/src/use_case/AddSong/AddSongInputData.java
+++ b/src/use_case/AddSong/AddSongInputData.java
@@ -1,6 +1,7 @@
 package use_case.AddSong;
 
 import entities.Playlist;
+import entities.Song;
 
 public class AddSongInputData {
 

--- a/src/use_case/LogInSpotify/LogInSpotifyDataAccessInterface.java
+++ b/src/use_case/LogInSpotify/LogInSpotifyDataAccessInterface.java
@@ -1,0 +1,10 @@
+package use_case.LogInSpotify;
+
+import entities.SpotifyAccount;
+
+import javax.security.auth.login.FailedLoginException;
+import java.io.IOException;
+
+public interface LogInSpotifyDataAccessInterface {
+    SpotifyAccount createSpotifyAccountFromCode(String callbackCode) throws IOException, FailedLoginException;
+}

--- a/src/use_case/LogInSpotify/LogInSpotifyInputBoundary.java
+++ b/src/use_case/LogInSpotify/LogInSpotifyInputBoundary.java
@@ -1,0 +1,4 @@
+package use_case.LogInSpotify;
+
+public interface LogInSpotifyInputBoundary {
+}

--- a/src/use_case/LogInSpotify/LogInSpotifyInputData.java
+++ b/src/use_case/LogInSpotify/LogInSpotifyInputData.java
@@ -3,8 +3,8 @@ package use_case.LogInSpotify;
 import entities.Account;
 
 public class LogInSpotifyInputData {
-    private String code;
-    private Account activeAccount;
+    private final String code;
+    private final Account activeAccount;
 
     public LogInSpotifyInputData(String code, Account activeAccount) {
         this.code = code;

--- a/src/use_case/LogInSpotify/LogInSpotifyInputData.java
+++ b/src/use_case/LogInSpotify/LogInSpotifyInputData.java
@@ -1,0 +1,4 @@
+package use_case.LogInSpotify;
+
+public interface LogInSpotifyInputData {
+}

--- a/src/use_case/LogInSpotify/LogInSpotifyInputData.java
+++ b/src/use_case/LogInSpotify/LogInSpotifyInputData.java
@@ -1,13 +1,20 @@
 package use_case.LogInSpotify;
 
-public class LogInSpotifyInputData {
-    String code;
+import entities.Account;
 
-    public LogInSpotifyInputData(String code) {
+public class LogInSpotifyInputData {
+    private String code;
+    private Account activeAccount;
+
+    public LogInSpotifyInputData(String code, Account activeAccount) {
         this.code = code;
+        this.activeAccount = activeAccount;
     }
 
     public String getCode(){
         return code;
+    }
+    public Account getActiveAccount(){
+        return activeAccount;
     }
 }

--- a/src/use_case/LogInSpotify/LogInSpotifyInteractor.java
+++ b/src/use_case/LogInSpotify/LogInSpotifyInteractor.java
@@ -1,0 +1,7 @@
+package use_case.LogInSpotify;
+
+public class LogInSpotifyInteractor {
+    public LogInSpotifyOutputData execute(){
+
+    }
+}

--- a/src/use_case/LogInSpotify/LogInSpotifyInteractor.java
+++ b/src/use_case/LogInSpotify/LogInSpotifyInteractor.java
@@ -1,9 +1,36 @@
 package use_case.LogInSpotify;
 
-public class LogInSpotifyInteractor {
+import entities.SpotifyAccount;
+
+import javax.security.auth.login.FailedLoginException;
+import java.io.IOException;
+
+public class LogInSpotifyInteractor implements LogInSpotifyInputBoundary {
+    private LogInSpotifyOutputBoundary presenter;
+    private LogInSpotifyDataAccessInterface dataAccessInterface;
+
+    public LogInSpotifyInteractor(LogInSpotifyOutputBoundary presenter, LogInSpotifyDataAccessInterface logInSpotifyDataAccessInterface) {
+        this.presenter = presenter;
+        this.dataAccessInterface = logInSpotifyDataAccessInterface;
+    }
+
+
     public void execute(LogInSpotifyInputData inputData){
         String callback_code = inputData.getCode();
 
+        SpotifyAccount spotifyAccount;
+
+        try {
+            spotifyAccount = dataAccessInterface.createSpotifyAccountFromCode(callback_code);
+        } catch (IOException | FailedLoginException e) {
+            //either no failed to complete API request or bad login.
+            presenter.prepareFailView();
+            return;
+        }
+
+        inputData.getActiveAccount().addMusicService(spotifyAccount);
+
+        presenter.prepareSuccessView();
 
     }
 }

--- a/src/use_case/LogInSpotify/LogInSpotifyInteractor.java
+++ b/src/use_case/LogInSpotify/LogInSpotifyInteractor.java
@@ -1,7 +1,5 @@
 package use_case.LogInSpotify;
 
 public class LogInSpotifyInteractor {
-    public LogInSpotifyOutputData execute(){
 
-    }
 }

--- a/src/use_case/LogInSpotify/LogInSpotifyOutputBoundary.java
+++ b/src/use_case/LogInSpotify/LogInSpotifyOutputBoundary.java
@@ -1,0 +1,6 @@
+package use_case.LogInSpotify;
+
+public interface LogInSpotifyOutputBoundary {
+    void prepareSuccessView();
+    void prepareFailView();
+}

--- a/src/use_case/OpenLoginSpotify/OpenLoginSpotifyDataAccessInterface.java
+++ b/src/use_case/OpenLoginSpotify/OpenLoginSpotifyDataAccessInterface.java
@@ -1,0 +1,5 @@
+package use_case.OpenLoginSpotify;
+
+public interface OpenLoginSpotifyDataAccessInterface {
+    String getLoginPage();
+}

--- a/src/use_case/OpenLoginSpotify/OpenLoginSpotifyInputBoundary.java
+++ b/src/use_case/OpenLoginSpotify/OpenLoginSpotifyInputBoundary.java
@@ -1,0 +1,5 @@
+package use_case.OpenLoginSpotify;
+
+public interface OpenLoginSpotifyInputBoundary {
+    void execute();
+}

--- a/src/use_case/OpenLoginSpotify/OpenLoginSpotifyInteractor.java
+++ b/src/use_case/OpenLoginSpotify/OpenLoginSpotifyInteractor.java
@@ -1,0 +1,13 @@
+package use_case.OpenLoginSpotify;
+
+public class OpenLoginSpotifyInteractor implements OpenLoginSpotifyInputBoundary{
+    OpenLoginSpotifyOutputBoundary openPresenter;
+    OpenLoginSpotifyDataAccessInterface dataAccessObject;
+    public OpenLoginSpotifyInteractor(OpenLoginSpotifyOutputBoundary openLoginSpotifyOutputBoundary){
+        openPresenter = openLoginSpotifyOutputBoundary;
+    }
+    public void execute() {
+        OpenLoginSpotifyOutputData outputData = new OpenLoginSpotifyOutputData(dataAccessObject.getLoginPage());
+        openPresenter.openLoginCallbackURL(outputData);
+    }
+}

--- a/src/use_case/OpenLoginSpotify/OpenLoginSpotifyOutputBoundary.java
+++ b/src/use_case/OpenLoginSpotify/OpenLoginSpotifyOutputBoundary.java
@@ -1,0 +1,5 @@
+package use_case.OpenLoginSpotify;
+
+public interface OpenLoginSpotifyOutputBoundary {
+    public void openLoginCallbackURL(OpenLoginSpotifyOutputData data);
+}

--- a/src/use_case/OpenLoginSpotify/OpenLoginSpotifyOutputData.java
+++ b/src/use_case/OpenLoginSpotify/OpenLoginSpotifyOutputData.java
@@ -1,0 +1,12 @@
+package use_case.OpenLoginSpotify;
+
+public class OpenLoginSpotifyOutputData {
+    String callback_url;
+    OpenLoginSpotifyOutputData(String callback_url){
+        this.callback_url = callback_url;
+    }
+
+    public String getCallback_url() {
+        return callback_url;
+    }
+}

--- a/src/use_case/RemoveSong/RemoveSongInputData.java
+++ b/src/use_case/RemoveSong/RemoveSongInputData.java
@@ -1,6 +1,7 @@
 package use_case.RemoveSong;
 
 import entities.Playlist;
+import entities.Song;
 
 public class RemoveSongInputData {
 

--- a/src/use_case/TransferPlaylist/TransferPlaylistInputData.java
+++ b/src/use_case/TransferPlaylist/TransferPlaylistInputData.java
@@ -3,6 +3,7 @@ package use_case.TransferPlaylist;
 import entities.Account;
 import entities.Playlist;
 
+import entities.*;
 public class TransferPlaylistInputData {
 
     final private Playlist playlist;

--- a/src/use_case/TransferPlaylist/TransferPlaylistInputData.java
+++ b/src/use_case/TransferPlaylist/TransferPlaylistInputData.java
@@ -1,5 +1,8 @@
 package use_case.TransferPlaylist;
 
+import entities.Account;
+import entities.Playlist;
+
 public class TransferPlaylistInputData {
 
     final private Playlist playlist;

--- a/src/use_case/TransferPlaylist/TransferPlaylistInteractor.java
+++ b/src/use_case/TransferPlaylist/TransferPlaylistInteractor.java
@@ -1,6 +1,6 @@
 package use_case.TransferPlaylist;
 
-public class TransferPlaylistInteractor extends TransferPlaylistInputBoundary {
+public class TransferPlaylistInteractor implements TransferPlaylistInputBoundary {
     final TransferPlaylistDataAccessInterface playlistDataAccessObject;
     final TransferPlaylistOutputBoundary playlistPresenter;
 

--- a/tests/entities/TestSpotifyAccount.java
+++ b/tests/entities/TestSpotifyAccount.java
@@ -9,23 +9,5 @@ import java.util.List;
 
 public class TestSpotifyAccount {
     SpotifyAccount spotifyAccount;
-    @Before
-    public void init(){
-        spotifyAccount = new SpotifyAccount();
-        spotifyAccount.openLoginPage(true);
-        spotifyAccount.createNewUserAccessToken(spotifyAccount.getCodeFromURI(JOptionPane.showInputDialog("enter redirected url")));
-    }
-    @Test
-    public void TestGetPlaylists() {
-        try {
-            List<Playlist> playlists = spotifyAccount.getPlaylists();
-            for (Playlist p : playlists){
-                System.out.println(p.getName());
-            }
-            assert(!playlists.isEmpty());
-        } catch (SpotifyAccount.NoAccessTokenException e) {
-            throw new RuntimeException(e);
-        }
 
-    }
 }


### PR DESCRIPTION
Use case to open a login page to grant DG access to the user spotify account, and use case to use that login page redirect to create access token for user in DG is done if not mostly fleshed out. This also moves most of the data access functionality out of the SpotifyAccount Object.